### PR TITLE
Support 6.10 kernels

### DIFF
--- a/mt76/mt792x.h
+++ b/mt76/mt792x.h
@@ -4,6 +4,7 @@
 #ifndef __MT792X_H
 #define __MT792X_H
 
+#include <linux/version.h>
 #include <linux/interrupt.h>
 #include <linux/ktime.h>
 
@@ -249,7 +250,11 @@ static inline bool mt7902_mt792x_dma_need_reinit(struct mt7902_mt792x_dev *dev)
 #define mt7902_mt792x_mutex_release(dev)	\
 	mt7902_mt76_connac_mutex_release(&(dev)->mt76, &(dev)->pm)
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0))
+void mt7902_mt792x_stop(struct ieee80211_hw *hw, bool suspend);
+#else
 void mt7902_mt792x_stop(struct ieee80211_hw *hw);
+#endif
 void mt7902_mt792x_pm_wake_work(struct work_struct *work);
 void mt7902_mt792x_pm_power_save_work(struct work_struct *work);
 void mt7902_mt792x_reset(struct mt7902_mt76_dev *mdev);
@@ -341,8 +346,8 @@ static inline char *mt7902_mt792x_ram_name(struct mt7902_mt792x_dev *dev)
 static inline char *mt7902_mt792x_patch_name(struct mt7902_mt792x_dev *dev)
 {
 	switch (mt7902_mt76_chip(&dev->mt76)) {
-        case 0x7902:
-                return MT7902_ROM_PATCH;
+	case 0x7902:
+		return MT7902_ROM_PATCH;
 	case 0x7922:
 		return MT7922_ROM_PATCH;
 	case 0x7925:

--- a/mt76/mt792x_core.c
+++ b/mt76/mt792x_core.c
@@ -91,7 +91,11 @@ void mt7902_mt792x_tx(struct ieee80211_hw *hw, struct ieee80211_tx_control *cont
 }
 EXPORT_SYMBOL_GPL(mt7902_mt792x_tx);
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0))
+void mt7902_mt792x_stop(struct ieee80211_hw *hw, bool suspend)
+#else
 void mt7902_mt792x_stop(struct ieee80211_hw *hw)
+#endif
 {
 	struct mt7902_mt792x_dev *dev = mt7902_mt792x_hw_dev(hw);
 	struct mt7902_mt792x_phy *phy = mt7902_mt792x_hw_phy(hw);


### PR DESCRIPTION
This is to support 6.10 Kernels just released.

Minor whitespace changes as well (to match reset of file).